### PR TITLE
Add spell icons and cosmetic changes

### DIFF
--- a/Main.lua
+++ b/Main.lua
@@ -15,39 +15,61 @@ local dispels = {
     [4] = "Poison"
 }
 
+local icons = {
+    [1] = "Interface\\Icons\\Spell_fire_frostresistancetotem", -- Magic
+    [2] = "Interface\\Icons\\ability_creature_cursed_03", -- Curse
+    [3] = "Interface\\Icons\\Ability_creature_disease_03", -- Disease
+    [4] = "Interface\\Icons\\ability_creature_poison_05" -- Poison
+}
+
+local codexTooltip = CreateFrame("Frame", nil, GameTooltip)
+
 function Codex_OnTooltipShown()
     if UnitIsPlayer("mouseover") or not UnitCanAttack("player", "mouseover") then
         return
-    end
+    end    
 
     local unitName = UnitName("mouseover")
     if not unitName then
         return
-    end
+    end    
 
     local spellList = Codex_CreatureSpells[unitName]
     if spellList then
         for i, spell in ipairs(spellList) do
-            GameTooltip:AddLine(" "); 
+            GameTooltip:AddLine(" ")
+            GameTooltip:AddLine(" ")
 
             local schoolColor = colors[spell.school]
 
-            if spell.name and spell.dispel then
-                GameTooltip:AddDoubleLine(spell.name, "Dispel: " .. dispels[spell.dispel], schoolColor.r, schoolColor.g, schoolColor.b, schoolColor.r, schoolColor.g, schoolColor.b, true)
-            elseif spell.name then
-                GameTooltip:AddLine(spell.name, schoolColor.r, schoolColor.g, schoolColor.b, true)
+            codexTooltip.iconbg:Show()
+            if spell.dispel then
+                codexTooltip.icon:SetTexture(icons[spell.dispel])
+                codexTooltip.iconbg:SetBackdropBorderColor(schoolColor.r, schoolColor.g, schoolColor.b)
             else
-                GameTooltip:AddLine("Unknown spell")
+                codexTooltip.icon:SetTexture("Interface\\Icons\\Inv_misc_questionmark")
+                codexTooltip.iconbg:SetBackdropBorderColor(1, 0, 0)
             end
 
+            local numLines = GameTooltip:NumLines();
+	        codexTooltip.iconbg:SetPoint("TOP", GameTooltip:GetName().."TextLeft"..numLines, "BOTTOM", 10, 24)           
+            
+            if spell.name then
+                codexTooltip.name:SetText(spell.name)
+                codexTooltip.name:SetTextColor(schoolColor.r, schoolColor.g, schoolColor.b)
+            else
+                codexTooltip.name:SetText("Unknown spell")
+                codexTooltip.name:SetTextColor(0.8, 0.8, 0.8)
+            end
+            
             if spell.subname then
-                GameTooltip:AddLine(spell.subname, 0.8, 0.8, 0.8, true)
+                codexTooltip.subname:SetText("("..spell.subname..")")
             end
 
             if spell.description then
-                GameTooltip:AddLine(Codex_ParseDescription(spell.description), 1, 1, 1, true)
+                GameTooltip:AddLine(Codex_ParseDescription(spell.description), 0.8, 0.8, 0.8, true)
             else
-                GameTooltip:AddLine("Unknown spell effect.")
+                GameTooltip:AddLine("Unknown spell effect.", 0.8, 0.8, 0.8)
             end
         end 
 
@@ -65,5 +87,35 @@ function Codex_ParseDescription(spellDescription)
     return string.gsub(spellDescription, "$g([^:]+):([^;]+);", "%" .. (gender - 1))
 end
 
-local codexTooltip = CreateFrame("Frame", nil, GameTooltip)
+codexTooltip.iconbg = CreateFrame("Frame", nil, codexTooltip)
+codexTooltip.iconbg:SetWidth(26)
+codexTooltip.iconbg:SetHeight(26)
+codexTooltip.iconbg:SetBackdrop({
+    edgeFile = 'Interface\\Tooltips\\UI-Tooltip-Border',
+    tile = true, tileSize = 12, edgeSize = 12,
+    insets = { left = 2, right = 2, top = 2, bottom = 2 }
+})
+
+codexTooltip.icon = codexTooltip:CreateTexture(nil, 'ARTWORK')
+codexTooltip.icon:SetWidth(24)
+codexTooltip.icon:SetHeight(24)
+codexTooltip.icon:SetPoint("TOPLEFT", codexTooltip.iconbg, "TOPLEFT", 2, -2)
+codexTooltip.icon:SetPoint("BOTTOMRIGHT", codexTooltip.iconbg, "BOTTOMRIGHT", -2, 2)
+
+codexTooltip.name = codexTooltip:CreateFontString("Status", "LOW", "GameFontNormal")
+codexTooltip.name:SetFont(STANDARD_TEXT_FONT, 12)
+codexTooltip.name:SetPoint("TOPLEFT", codexTooltip.icon, "TOPRIGHT", 2, 0)
+
+codexTooltip.subname = codexTooltip:CreateFontString("Status", "LOW", "GameFontNormal")
+codexTooltip.subname:SetFont(STANDARD_TEXT_FONT, 10)
+codexTooltip.subname:SetPoint("BOTTOMLEFT", codexTooltip.icon, "BOTTOMRIGHT", 2, 0)
+codexTooltip.subname:SetTextColor(.9, .7, 0)
+
 codexTooltip:SetScript("OnShow", Codex_OnTooltipShown)
+codexTooltip:SetScript("OnHide", function()
+    codexTooltip.iconbg:ClearAllPoints()
+    codexTooltip.iconbg:Hide()
+    codexTooltip.icon:SetTexture(nil)
+    codexTooltip.name:SetText("")
+    codexTooltip.subname:SetText("")    
+end)


### PR DESCRIPTION
What a fantastic addon! many thanks for taking the time to do this!

I've added spell debuff icons (with debuff color border) and made some cosmetic changes to improve the overall appearance.
The space to the right of the icon under the spell name is where the subname will appear.

The icon positioning within the game tooltip is something I haven't tried before so there may be further testing required however it appears to work fine with the starting zone mobs. Please feel free to test this code and merge/adapt if you feel like doing so.

It's worth mentioning that if a spell does not have a debuff type a default "?" icon is used. Not sure if you prefer to have another default icon or an icon at all in this case. I have a version of the code that removes the icon in this case. Please let me know if you'd like me to supply this.

Preview of changes:
![image](https://user-images.githubusercontent.com/107083057/231842312-54a4d093-6cf3-4503-909b-bed775a7bf43.png)

![image](https://user-images.githubusercontent.com/107083057/231850764-66d18ae9-1cf0-4080-bfa8-e00d3a536bbf.png)

